### PR TITLE
Support measure readout noise

### DIFF
--- a/src/braket/circuits/noise_model/__init__.py
+++ b/src/braket/circuits/noise_model/__init__.py
@@ -26,6 +26,7 @@ from braket.circuits.noise_model.noise_model import (
     NoiseModelInstruction,  # noqa: F401
 )
 from braket.circuits.noise_model.observable_criteria import ObservableCriteria  # noqa: F401
+from braket.circuits.noise_model.measure_criteria import MeasureCriteria  # noqa: F401
 from braket.circuits.noise_model.qubit_initialization_criteria import (
     QubitInitializationCriteria,  # noqa: F401
 )

--- a/src/braket/circuits/noise_model/measure_criteria.py
+++ b/src/braket/circuits/noise_model/measure_criteria.py
@@ -1,0 +1,70 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from collections.abc import Iterable
+from typing import Any, Optional
+
+from braket.circuits.instruction import Instruction
+from braket.circuits.measure import Measure
+from braket.circuits.noise_model.circuit_instruction_criteria import CircuitInstructionCriteria
+from braket.circuits.noise_model.criteria import Criteria, CriteriaKey, CriteriaKeyResult
+from braket.circuits.noise_model.criteria_input_parsing import parse_qubit_input
+from braket.registers.qubit_set import QubitSetInput
+
+
+class MeasureCriteria(CircuitInstructionCriteria):
+    """This class models noise Criteria based on Measure instructions."""
+
+    def __init__(self, qubits: Optional[QubitSetInput] = None):
+        """Creates Measure-based Criteria.
+
+        Args:
+            qubits (Optional[QubitSetInput]): A set of relevant qubits. If no qubits are
+                provided, all (possible) qubits are considered to be relevant.
+        """
+        self._qubits = parse_qubit_input(qubits, 1)
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}({self._qubits})"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(qubits={self._qubits})"
+
+    def applicable_key_types(self) -> Iterable[CriteriaKey]:
+        """Returns an Iterable of criteria keys."""
+        return [CriteriaKey.QUBIT]
+
+    def get_keys(self, key_type: CriteriaKey) -> CriteriaKeyResult | set[Any]:
+        """Gets the keys for a given CriteriaKey."""
+        if key_type == CriteriaKey.QUBIT:
+            return CriteriaKeyResult.ALL if self._qubits is None else set(self._qubits)
+        return set()
+
+    def to_dict(self) -> dict:
+        """Converts this object to a dictionary."""
+        qubits = list(self._qubits) if self._qubits is not None else None
+        return {"__class__": self.__class__.__name__, "qubits": qubits}
+
+    def instruction_matches(self, instruction: Instruction) -> bool:
+        """Returns true if an Instruction matches the criteria."""
+        if not isinstance(instruction.operator, Measure):
+            return False
+        return CircuitInstructionCriteria._check_target_in_qubits(self._qubits, instruction.target)
+
+    @classmethod
+    def from_dict(cls, criteria: dict) -> Criteria:
+        """Deserializes a dictionary into a Criteria object."""
+        return MeasureCriteria(criteria["qubits"])
+
+
+Criteria.register_criteria(MeasureCriteria)

--- a/src/braket/circuits/noise_model/noise_model.py
+++ b/src/braket/circuits/noise_model/noise_model.py
@@ -19,8 +19,10 @@ from dataclasses import dataclass
 from braket.circuits.circuit import Circuit
 from braket.circuits.gate import Gate
 from braket.circuits.instruction import Instruction
+from braket.circuits.measure import Measure
 from braket.circuits.noise import Noise
 from braket.circuits.noise_model.circuit_instruction_criteria import CircuitInstructionCriteria
+from braket.circuits.noise_model.measure_criteria import MeasureCriteria
 from braket.circuits.noise_model.criteria import Criteria, CriteriaKey, CriteriaKeyResult
 from braket.circuits.noise_model.initialization_criteria import InitializationCriteria
 from braket.circuits.noise_model.result_type_criteria import ResultTypeCriteria
@@ -181,6 +183,8 @@ class NoiseModel:
         for item in self._instructions:
             if isinstance(item.criteria, InitializationCriteria):
                 init_noise.append(item)
+            elif isinstance(item.criteria, MeasureCriteria):
+                readout_noise.append(item)
             elif isinstance(item.criteria, CircuitInstructionCriteria):
                 gate_noise.append(item)
             elif isinstance(item.criteria, ResultTypeCriteria):
@@ -324,9 +328,21 @@ class NoiseModel:
         Returns:
             Circuit: The passed in circuit, with the readout noise applied.
         """
-        if not readout_noise_instructions or not circuit.result_types:
+        if not readout_noise_instructions:
             return circuit
-        return _apply_noise_on_observable_result_types(circuit, readout_noise_instructions)
+        measure_instructions = [
+            item for item in readout_noise_instructions if isinstance(item.criteria, MeasureCriteria)
+        ]
+        result_type_instructions = [
+            item for item in readout_noise_instructions if not isinstance(item.criteria, MeasureCriteria)
+        ]
+
+        new_circuit = circuit
+        if measure_instructions:
+            new_circuit = _apply_noise_on_measure_instructions(new_circuit, measure_instructions)
+        if result_type_instructions and new_circuit.result_types:
+            new_circuit = _apply_noise_on_observable_result_types(new_circuit, result_type_instructions)
+        return new_circuit
 
     @classmethod
     def _items_to_string(
@@ -394,3 +410,34 @@ def _apply_noise_on_observable_result_types(
             item = readout_noise_instructions[noise_item_index]
             circuit.apply_readout_noise(item.noise, qubit)
     return circuit
+
+
+def _apply_noise_on_measure_instructions(
+    circuit: Circuit, measure_noise_instructions: list[NoiseModelInstruction]
+) -> Circuit:
+    """Applies readout noise based on the Measure instructions in the circuit.
+
+    Args:
+        circuit (Circuit): The circuit to apply the readout noise to.
+        measure_noise_instructions (list[NoiseModelInstruction]): The list of readout noise
+            to apply.
+
+    Returns:
+        Circuit: The passed in circuit, with the readout noise applied before each matching
+        measure instruction.
+    """
+    new_circuit = Circuit()
+    for instruction in circuit.instructions:
+        if isinstance(instruction.operator, Measure):
+            target_qubits = list(instruction.target)
+            for item in measure_noise_instructions:
+                if item.criteria.instruction_matches(instruction):
+                    if item.noise.fixed_qubit_count() == len(target_qubits):
+                        new_circuit.add_instruction(Instruction(item.noise, target_qubits))
+                    else:
+                        for qubit in target_qubits:
+                            new_circuit.add_instruction(Instruction(item.noise, qubit))
+        new_circuit.add_instruction(instruction)
+    for result_type in circuit.result_types:
+        new_circuit.add_result_type(result_type)
+    return new_circuit

--- a/test/unit_tests/braket/circuits/noise/test_noise_model.py
+++ b/test/unit_tests/braket/circuits/noise/test_noise_model.py
@@ -21,6 +21,7 @@ from braket.circuits.noise_model import (
     CircuitInstructionCriteria,
     Criteria,
     GateCriteria,
+    MeasureCriteria,
     NoiseModel,
     ObservableCriteria,
     QubitInitializationCriteria,
@@ -462,6 +463,14 @@ def test_apply_initialization_noise(noise_model, input_circuit, expected_circuit
 def test_apply_readout_noise(noise_model, input_circuit, expected_circuit):
     result_circuit = noise_model.apply(input_circuit)
     assert result_circuit == expected_circuit
+
+
+def test_apply_measure_readout_noise():
+    noise_model = NoiseModel().add_noise(BitFlip(0.1), MeasureCriteria([0]))
+    circuit = Circuit().x(0).x(1).measure(0)
+    noisy = noise_model.apply(circuit)
+    expected = Circuit().x(0).x(1).bit_flip(0, probability=0.1).measure(0)
+    assert noisy == expected
 
 
 @pytest.mark.xfail(raises=IndexError)


### PR DESCRIPTION
## Summary
- add `MeasureCriteria` to match measurement instructions
- classify `MeasureCriteria` instructions as readout noise
- apply readout noise to matching `measure` instructions
- test readout noise on measure instructions

## Testing
- `PYTHONPATH=./src pytest test/unit_tests/braket/circuits/noise/test_noise_model.py::test_apply_measure_readout_noise -q`